### PR TITLE
Correct "School" replacements on stats and user form

### DIFF
--- a/app/views/stats/schools.html.erb
+++ b/app/views/stats/schools.html.erb
@@ -84,10 +84,10 @@
 <div id="wrapper">
     <div id="sidebar-wrapper">
         <ul class="nav nav-pills sidebar-nav nav-stacked" role="tablist">
-			<li role="presentation"><a href="#">Top</a></li>
-			<li role="presentation"><a href="#Graph1">Students Per School</a></li>
-		    <li role="presentation"><a href="#Graph2">Hours Per School</a></li>
-		    <li role="presentation"><a href="#Graph3">Hours Per Student Per School</a></li>
+          <li role="presentation"><a href="#">Top</a></li>
+          <li role="presentation"><a href="#Graph1">Students Per <%=Constants::SCHOOL_NAME_REPLACEMENT%></a></li>
+          <li role="presentation"><a href="#Graph2">Hours Per <%=Constants::SCHOOL_NAME_REPLACEMENT%></a></li>
+          <li role="presentation"><a href="#Graph3">Hours Per Student Per <%=Constants::SCHOOL_NAME_REPLACEMENT%></a></li>
         </ul>
     </div>
     <div id="page-content-wrapper">

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -19,7 +19,7 @@ wrapper_mappings: {
 				<%= f.input :email, :as=>:email%>
 			
 				<%= f.input :phone, :label=>"Phone Number"%>
-				<%= f.input :school_id, collection: School.order("lower(name)"),:label_method =>:name, input_html: {:include_blank => true}%>
+				<%= f.input :school_id, collection: School.order("lower(name)"),:label=>Constants::SCHOOL_NAME_REPLACEMENT, input_html: {:include_blank => true}%>
 				<%= f.input :location%>
 				<%= f.input :gender, collection: Constants::GENDERS%>
 				<%= f.input :graduation_year%>


### PR DESCRIPTION
Both the stats page and the user form had some hardcoded "School" labels. This PR replaces those with the proper school name replacement.