### PR TITLE
Default login fix

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
       session[:user_id] = user.id
       if user.try(:admin)
         redirect_to root_url, :notice => "Logged in!"
-      elsif user.email == Constants::DEFAULT_LOGIN
+      elsif user.is_default_user
         redirect_to studentlogin_path
       else
         redirect_to user_path(user.id), :notice => "Logged in!"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
     @preseasonMin = Year.preseason_weeks
     
     @users.each do |user|
-      if user.email == Constants::DEFAULT_LOGIN
+      if user.is_default_user
       elsif user.is_mentor
         @numMentors = @numMentors + 1
       else
@@ -40,7 +40,7 @@ class UsersController < ApplicationController
     @numStudents = 0
     
     @users.each do |user|
-      if user.email == Constants::DEFAULT_LOGIN
+      if user.is_default_user
       elsif user.is_mentor
         @numMentors = @numMentors + 1
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,9 @@ class User < ActiveRecord::Base
     end
     return false
   end
+  def is_default_user
+    self.email == Constants::DEFAULT_LOGIN
+  end
   def full_name
     return "#{self.name_first} #{self.name_last}"
   end

--- a/app/views/layouts/_navIn.html.erb
+++ b/app/views/layouts/_navIn.html.erb
@@ -7,7 +7,7 @@
   <!-- Collect the nav links, forms, and other content for toggling -->
   <div>
     <ul class="nav navbar-nav">
-		<%if current_user.email == Constants::DEFAULT_LOGIN || current_user.try(:admin)%>
+		<%if current_user.is_default_user || current_user.try(:admin)%>
 			<li><%=link_to "Student Login", studentlogin_path%></li>
 		<%end%>
 		

--- a/app/views/timelogs/student.html.erb
+++ b/app/views/timelogs/student.html.erb
@@ -1,5 +1,5 @@
 <h1>New timelog</h1>
-<%if current_user.try(:admin) || current_user.email == "signup@team900.org"%>
+<%if current_user.try(:admin) || current_user.is_default_user%>
 <%= form_for @timelog do |f| %>
   <div class="field">
     <%="User Number" %><br />

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -15,7 +15,7 @@
 		</div>
 	<%end%>
 	<h2>Important Links</h2>
-	<%if current_user.email == "signup@team900.org"%>
+	<%if current_user.is_default_user%>
 		<h4>Check-in Page</h4>
 		<li><%=link_to "Student Login", studentlogin_path%></li>
 	<%end%>


### PR DESCRIPTION
This fixes two cases in which the application isn't checking the proper default login email address if a different (not "signup@team900.org") email is specified in the config.