### PR TITLE
Fix for crash when getting active users with non-postgresql databases

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ActiveRecord::Base
   
   ###################### General Info ##########################
   def self.active
-    where("users.archive IS NOT true")
+    where(:archive => false)
   end
   def is_mentor
     if !self.school.nil? && self.school.name=="Mentor"


### PR DESCRIPTION
Non-PostgreSQL databases throw exceptions like this:

    SQLite3::SQLException: no such column: true: SELECT "users".* FROM "users" WHERE (users.archive IS NOT true)  ORDER BY name_first

This allows the database adapter to correctly convert the archive = false requirement to a DB statement