### PR TITLE
Fix crash when attempting to use a stale session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   
   private
     def current_user
-      @current_user ||= User.find(session[:user_id]) if session[:user_id]
+      @current_user ||= User.find_by_id(session[:user_id]) if session[:user_id]
     end
 end


### PR DESCRIPTION
If you logged in with a user, delete that user (from a different session), then tried to refresh the application, it would crash.

Generally you likely wouldn't see this in the wild, but I saw this in development whenever I wipe my database or otherwise delete a user I'm logged in with. `find_by_id` will default to null, whereas `find` crashes if it can't find a matching record.