### PR TITLE
Defaulted boolean fields to false

### DIFF
--- a/db/migrate/20161222211815_make_user_active_default_false.rb
+++ b/db/migrate/20161222211815_make_user_active_default_false.rb
@@ -1,0 +1,4 @@
+class MakeUserActiveDefaultFalse < ActiveRecord::Migration
+  User.where(archive: nil).update_all(archive: false)
+  change_column :users, :archive, :boolean, null: false, default: false
+end

--- a/db/migrate/20161222211846_make_user_admin_default_false.rb
+++ b/db/migrate/20161222211846_make_user_admin_default_false.rb
@@ -1,0 +1,6 @@
+class MakeUserAdminDefaultFalse < ActiveRecord::Migration
+  def change
+    User.where(admin: nil).update_all(admin: false)
+    change_column :users, :admin, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20161222211955_make_forms_archive_default_false.rb
+++ b/db/migrate/20161222211955_make_forms_archive_default_false.rb
@@ -1,0 +1,6 @@
+class MakeFormsArchiveDefaultFalse < ActiveRecord::Migration
+  def change
+    Form.where(archive: nil).update_all(archive: false)
+    change_column :forms, :archive, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20161222212049_make_forms_required_default_false.rb
+++ b/db/migrate/20161222212049_make_forms_required_default_false.rb
@@ -1,0 +1,6 @@
+class MakeFormsRequiredDefaultFalse < ActiveRecord::Migration
+  def change
+    Form.where(required: nil).update_all(required: false)
+    change_column :forms, :required, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20161222212738_make_hours_exception_made_up_hours_default_false.rb
+++ b/db/migrate/20161222212738_make_hours_exception_made_up_hours_default_false.rb
@@ -1,0 +1,6 @@
+class MakeHoursExceptionMadeUpHoursDefaultFalse < ActiveRecord::Migration
+  def change
+    HourException.where(made_up_hours: nil).update_all(made_up_hours: false)
+    change_column :hour_exceptions, :made_up_hours, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,10 +18,10 @@ ActiveRecord::Schema.define(version: 20160124164457) do
 
   create_table "forms", force: :cascade do |t|
     t.string   "name",       limit: 255
-    t.boolean  "archive"
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
-    t.boolean  "required"
+    t.boolean  "archive",    default: false, null: false
+    t.boolean  "required",   default: false, null: false
   end
 
   create_table "forms_users", force: :cascade do |t|
@@ -101,21 +101,21 @@ ActiveRecord::Schema.define(version: 20160124164457) do
     t.string   "last_sign_in_ip",        limit: 255
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
-    t.boolean  "admin"
     t.string   "phone",                  limit: 255
     t.string   "name_first",             limit: 255
     t.string   "name_last",              limit: 255
     t.string   "userid",                 limit: 255
+    t.boolean  "admin",                  default: false, null: false
     t.integer  "school_id"
     t.boolean  "tools"
     t.boolean  "conduct"
     t.boolean  "basicSafety"
     t.string   "password_salt",          limit: 255
     t.string   "password_hash",          limit: 255
-    t.boolean  "archive"
     t.string   "location",               limit: 255
     t.string   "gender",                 limit: 255
     t.string   "graduation_year",        limit: 255
+    t.boolean  "archive",                default: false, null: false
     t.boolean  "student_leader"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 20160124164457) do
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
     t.integer  "week_id"
-    t.boolean  "made_up_hours"
+    t.boolean  "made_up_hours",   default: false, null: false
   end
 
   add_index "hour_exceptions", ["user_id"], name: "index_hour_exceptions_on_user_id", using: :btree


### PR DESCRIPTION
Defaults all boolean fields to false, and migrates all existing null values to false.

Avoids the thee state boolean problem, in which we have true, false, and null as valid options. Also allows replacing the relatively verbose `user.try(:admin)` with the much cleaner `user.admin?`.

Affects the following fields:

Users
 * Archive
 * Admin

Forms
 * Archive
 * Required

Hour Exception
 * Made up hours